### PR TITLE
Add ipcheck role

### DIFF
--- a/flux.yml
+++ b/flux.yml
@@ -43,3 +43,7 @@
     - name: Watchdog Role
       ansible.builtin.import_role:
         name: watchdog
+
+    - name: IP Check Role
+      ansible.builtin.import_role:
+        name: ipcheck

--- a/roles/ipcheck/tasks/ipcheck-install.yml
+++ b/roles/ipcheck/tasks/ipcheck-install.yml
@@ -1,0 +1,20 @@
+---
+- name: Add IP Check script
+  ansible.builtin.template:
+    src: ip_check.j2
+    dest: "/home/{{ global.user }}/ip_check.sh"
+    owner: "{{ global.user }}"
+    group: "{{ global.user }}"
+    mode: "0755"
+
+- name: Create cron entries for ip_check.sh
+  ansible.builtin.cron:
+    name: "{{ item.name }}"
+    user: "{{ global.user }}"
+    job: "{{ item.job }}"
+    special_time: "{{ item.specialtime | default(omit) }}"
+    minute: "{{ item.minute | default(omit) }}"
+    state: present
+  loop:
+    - {name: 'Restart on boot', job: "env USER=$LOGNAME $HOME/ip_check.sh restart", specialtime: 'reboot'}
+    - {name: 'Check IP every 15 minutes', job: "env USER=$LOGNAME $HOME/ip_check.sh ip_check", minute: "*/15"}

--- a/roles/ipcheck/tasks/ipcheck-purge.yml
+++ b/roles/ipcheck/tasks/ipcheck-purge.yml
@@ -1,0 +1,18 @@
+---
+- name: Remove IP Check script
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - "/home/{{ global.user }}/ip_check.sh"
+    - "/home/{{ global.user }}/ip_history.log"
+
+- name: Remove Cron Entries
+  ansible.builtin.cron:
+    name: "{{ item.name }}"
+    user: "{{ global.user }}"
+    job: "{{ item.job }}"
+    state: absent
+  loop:
+    - {name: 'Restart on boot', job: "env USER=$LOGNAME $HOME/ip_check.sh restart"}
+    - {name: 'Check IP every 15 minutes', job: "env USER=$LOGNAME $HOME/ip_check.sh ip_check"}

--- a/roles/ipcheck/tasks/main.yml
+++ b/roles/ipcheck/tasks/main.yml
@@ -1,0 +1,28 @@
+---
+- name: Install IP Check Script
+  ansible.builtin.include_tasks:
+    file: ipcheck-install.yml
+    apply:
+      tags:
+        - ipcheck-install
+        - ipcheck
+        - all
+      become: true
+  tags:
+    - ipcheck-install
+    - ipcheck
+    - all
+    - never
+
+- name: Remove IP Check Script
+  ansible.builtin.include_tasks:
+    file: ipcheck-purge.yml
+    apply:
+      tags:
+        - ipcheck-purge
+        - purge
+      become: true
+  tags:
+    - ipcheck-purge
+    - purge
+    - never

--- a/roles/ipcheck/templates/ip_check.j2
+++ b/roles/ipcheck/templates/ip_check.j2
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+function get_ip(){
+  WANIP=$(curl --silent -m 10 https://api4.my-ip.io/ip | tr -dc '[:alnum:].')
+  if [[ "$WANIP" == "" || "$WANIP" = *html* ]]; then
+    WANIP=$(curl --silent -m 10 https://checkip.amazonaws.com | tr -dc '[:alnum:].')
+  fi
+  if [[ "$WANIP" == "" || "$WANIP" = *html* ]]; then
+    WANIP=$(curl --silent -m 10 https://api.ipify.org | tr -dc '[:alnum:].')
+  fi
+}
+function get_device_name(){
+  if [[ -f /home/$USER/device_conf.json ]]; then
+    device_name=$(jq -r .device_name /home/$USER/device_conf.json)
+  else
+    device_name=$(ip addr | grep 'BROADCAST,MULTICAST,UP,LOWER_UP' | head -n1 | awk '{print $2}' | sed 's/://' | sed 's/@/ /' | awk '{print $1}')
+  fi
+}
+function update_ip(){
+  ip_exists="0"
+  get_ip
+  get_device_name
+  if [[ "$device_name" != "" && "$WANIP" =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+    for i in $(ip --oneline addr show ${device_name} | grep "/32" | awk '{print $4}');
+    do
+      if [[ $i == "${WANIP}/32"  ]]; then
+        ip_exists="1"
+      else
+        sudo ip addr del $i dev $device_name
+      fi
+    done
+    if [[ "$ip_exists" == "0" ]]; then
+      date_timestamp=$(date '+%Y-%m-%d %H:%M:%S')
+      echo -e "New IP detected during $1, IP: $WANIP was added to $device_name at $date_timestamp" >> /home/$USER/ip_history.log
+      sudo ip addr add $WANIP dev $device_name && sleep 2
+    fi
+  fi
+}
+if [[ $1 == "restart" ]]; then
+  #give 3min to connect with internet
+  sleep 180
+fi
+update_ip $1


### PR DESCRIPTION
Adds ip_check.sh script and cron job install and purge.

This is an ip_check script that I modified to not rely on checking fluxOS and simplified it to only have a single function. Upon restart it will add a delay before running the script, that is essentially the only difference between the two cron entries.

This a separate role so we can easily update this in the future if needed.