### PR TITLE
Add thunder and speedtestserver to fluxbench conf

### DIFF
--- a/roles/fluxbench/tasks/fluxbench-conf.yml
+++ b/roles/fluxbench/tasks/fluxbench-conf.yml
@@ -6,6 +6,10 @@
     owner: "{{ global.user }}"
     group: "{{ global.user }}"
     mode: "0700"
+  when:
+    - (hostvars[inventory_hostname].gateway is defined and hostvars[inventory_hostname].apiport is defined) or
+      user[hostvars[inventory_hostname].user][hostvars[inventory_hostname].n]['thunder'] is defined or
+      user[hostvars[inventory_hostname].user][hostvars[inventory_hostname].n]['speed_test_id'] is defined
 
 - name: Generate Fluxbench config
   ansible.builtin.template:
@@ -14,3 +18,16 @@
     owner: "{{ global.user }}"
     group: "{{ global.user }}"
     mode: "0664"
+  when:
+    - (hostvars[inventory_hostname].gateway is defined and hostvars[inventory_hostname].apiport is defined) or
+      user[hostvars[inventory_hostname].user][hostvars[inventory_hostname].n]['thunder'] is defined or
+      user[hostvars[inventory_hostname].user][hostvars[inventory_hostname].n]['speed_test_id'] is defined
+
+- name: Verify fluxbench Conf
+  ansible.builtin.file:
+    dest: "{{ fluxbench.conf_file }}"
+    state: absent
+  when:
+    - (hostvars[inventory_hostname].gateway is not defined or hostvars[inventory_hostname].apiport is not defined)
+    - user[hostvars[inventory_hostname].user][hostvars[inventory_hostname].n]['thunder'] is not defined
+    - user[hostvars[inventory_hostname].user][hostvars[inventory_hostname].n]['speed_test_id'] is not defined

--- a/roles/fluxbench/templates/fluxbench.j2
+++ b/roles/fluxbench/templates/fluxbench.j2
@@ -1,2 +1,9 @@
-fluxport={{ hostvars[inventory_hostname].apiport | default(16127)}}
-
+{% if hostvars[inventory_hostname].apiport is defined and hostvars[inventory_hostname].gateway is defined %}
+fluxport={{ hostvars[inventory_hostname].apiport }}
+{% endif %}
+{% if user[hostvars[inventory_hostname].user][hostvars[inventory_hostname].n]['thunder'] is defined %}
+thunder={{ user[hostvars[inventory_hostname].user][hostvars[inventory_hostname].n]['thunder'] }}
+{% endif %}
+{% if user[hostvars[inventory_hostname].user][hostvars[inventory_hostname].n]['speed_test_id'] is defined %}
+speedtestserverid={{ user[hostvars[inventory_hostname].user][hostvars[inventory_hostname].n]['speed_test_id'] }}
+{% endif %}


### PR DESCRIPTION
This adds dynamics fluxbench.conf file generation.

If **_any_** of the variables **_exist_** it will create the fluxbench.conf file and will only add that variable to the file.

If **_all_** of the variables **_do not exist_** then it will remove the fluxbench.conf file or not create it.

For default installs, without UPnP, Thunder or SpeeedTestServerID this file is not create and isn't necessary to have fluxbench load.