### PR TITLE
Update MongoDB Version

### DIFF
--- a/roles/docker/tasks/docker-install.yml
+++ b/roles/docker/tasks/docker-install.yml
@@ -30,6 +30,9 @@
     groups: docker
     append: true
 
+- name: Reset SSH connection for docker group
+  ansible.builtin.meta: reset_connection
+
 - name: Start Docker service
   ansible.builtin.service:
     name: docker

--- a/roles/mongo/README.md
+++ b/roles/mongo/README.md
@@ -27,6 +27,8 @@ mongo:
   list4: # Path to MongoDB 4.4 APT source list
   path6: # Path to MongoDB 6.0 APT key
   list6: # Path to MongoDB 6.0 APT source list
+  path7: # Path to MongoDB 7.0 APT key
+  list7: # Path to MongoDB 7.0 APT source list
   mongo4:
   # packages takes a list of dictionaries with the following keys:
     packages:

--- a/roles/mongo/tasks/mongo-install.yml
+++ b/roles/mongo/tasks/mongo-install.yml
@@ -18,10 +18,10 @@
     - ansible_distribution_release == 'focal'
     - avx_check.stdout == '0'
 
-- name: Add mongo key 7.0
+- name: Add mongo key
   ansible.builtin.apt_key:
     keyring: "{{ mongo.keyring }}"
-    url: "{{ mongo.path7 }}"
+    url: "{{ mongo.path }}"
   when:
     - (ansible_distribution_release == 'focal' or ansible_distribution_release == 'jammy')
     - avx_check.stdout != '0'
@@ -37,12 +37,12 @@
     - ansible_distribution_release == 'focal'
     - avx_check.stdout == '0'
 
-- name: Add APT Repository 7.0
+- name: Add APT Repository
   ansible.builtin.apt_repository:
     repo: "deb [arch={{ system_arch }} signed-by={{ mongo.keyring }}]
       https://repo.mongodb.org/apt/{{ ansible_distribution | lower }} {{ ansible_distribution_release }}/mongodb-org/7.0 multiverse"
     state: present
-    filename: "{{ mongo.list7 }}"
+    filename: "{{ mongo.list }}"
     mode: 644
   when:
     - (ansible_distribution_release == 'focal' or ansible_distribution_release == 'jammy')
@@ -58,7 +58,7 @@
     - ansible_distribution_release == 'focal'
     - avx_check.stdout == '0'
 
-- name: Install Mongo 7.0
+- name: Install Mongo
   ansible.builtin.apt:
     name:
       - mongodb-org

--- a/roles/mongo/tasks/mongo-install.yml
+++ b/roles/mongo/tasks/mongo-install.yml
@@ -48,6 +48,15 @@
     - (ansible_distribution_release == 'focal' or ansible_distribution_release == 'jammy')
     - avx_check.stdout != '0'
 
+# This is just to cleanup the depricated repo file
+# that was created when we used mongo.path6 and mongo.list6
+# This can be removed sometime in the future when we are sure
+# that no one is using the old repo file
+- name: Cleanup Depricated Repo File
+  ansible.builtin.file:
+    path: /etc/apt/sources.list.d/mongodb-org-6.0
+    state: absent
+
 - name: Install Mongo 4.0
   ansible.builtin.apt:
     name: "{{ item.name }}={{ item.version }}"

--- a/roles/mongo/tasks/mongo-install.yml
+++ b/roles/mongo/tasks/mongo-install.yml
@@ -18,10 +18,10 @@
     - ansible_distribution_release == 'focal'
     - avx_check.stdout == '0'
 
-- name: Add mongo key 6.0
+- name: Add mongo key 7.0
   ansible.builtin.apt_key:
     keyring: "{{ mongo.keyring }}"
-    url: "{{ mongo.path6 }}"
+    url: "{{ mongo.path7 }}"
   when:
     - (ansible_distribution_release == 'focal' or ansible_distribution_release == 'jammy')
     - avx_check.stdout != '0'
@@ -36,12 +36,12 @@
     - ansible_distribution_release == 'focal'
     - avx_check.stdout == '0'
 
-- name: Add APT Repository 6.0
+- name: Add APT Repository 7.0
   ansible.builtin.apt_repository:
     repo: "deb [arch={{ system_arch }} signed-by={{ mongo.keyring }}]
-      https://repo.mongodb.org/apt/{{ ansible_distribution | lower }} {{ ansible_distribution_release }}/mongodb-org/6.0 multiverse"
+      https://repo.mongodb.org/apt/{{ ansible_distribution | lower }} {{ ansible_distribution_release }}/mongodb-org/7.0 multiverse"
     state: present
-    filename: "{{ mongo.list6 }}"
+    filename: "{{ mongo.list7 }}"
   when:
     - (ansible_distribution_release == 'focal' or ansible_distribution_release == 'jammy')
     - avx_check.stdout != '0'
@@ -56,7 +56,7 @@
     - ansible_distribution_release == 'focal'
     - avx_check.stdout == '0'
 
-- name: Install Mongo 6.0
+- name: Install Mongo 7.0
   ansible.builtin.apt:
     name:
       - mongodb-org

--- a/roles/mongo/tasks/mongo-purge.yml
+++ b/roles/mongo/tasks/mongo-purge.yml
@@ -16,16 +16,10 @@
     url: "{{ mongo.path4 }}"
     state: absent
 
-- name: Remove mongo key 6.0
+- name: Remove mongo key
   ansible.builtin.apt_key:
     keyring: "{{ mongo.keyring }}"
-    url: "{{ mongo.path6 }}"
-    state: absent
-
-- name: Remove mongo key 7.0
-  ansible.builtin.apt_key:
-    keyring: "{{ mongo.keyring }}"
-    url: "{{ mongo.path7 }}"
+    url: "{{ mongo.path }}"
     state: absent
 
 - name: Removing APT Repository 4.0
@@ -35,19 +29,12 @@
     state: absent
     filename: "{{ mongo.list4 }}"
 
-- name: Remove APT Repository 6.0
-  ansible.builtin.apt_repository:
-    repo: "deb [arch={{ system_arch }} signed-by={{ mongo.keyring }}]
-      https://repo.mongodb.org/apt/{{ ansible_distribution | lower }} {{ ansible_distribution_release }}/mongodb-org/6.0 multiverse"
-    state: absent
-    filename: "{{ mongo.list6 }}"
-
-- name: Remove APT Repository 7.0
+- name: Remove APT Repository
   ansible.builtin.apt_repository:
     repo: "deb [arch={{ system_arch }} signed-by={{ mongo.keyring }}]
       https://repo.mongodb.org/apt/{{ ansible_distribution | lower }} {{ ansible_distribution_release }}/mongodb-org/7.0 multiverse"
     state: absent
-    filename: "{{ mongo.list7 }}"
+    filename: "{{ mongo.list }}"
 
 - name: Remove Mongo
   ansible.builtin.apt:

--- a/roles/mongo/tasks/mongo-purge.yml
+++ b/roles/mongo/tasks/mongo-purge.yml
@@ -22,6 +22,12 @@
     url: "{{ mongo.path6 }}"
     state: absent
 
+- name: Remove mongo key 7.0
+  ansible.builtin.apt_key:
+    keyring: "{{ mongo.keyring }}"
+    url: "{{ mongo.path7 }}"
+    state: absent
+
 - name: Removing APT Repository 4.0
   ansible.builtin.apt_repository:
     repo: "deb [arch={{ system_arch }} signed-by={{ mongo.keyring }}]
@@ -35,6 +41,13 @@
       https://repo.mongodb.org/apt/{{ ansible_distribution | lower }} {{ ansible_distribution_release }}/mongodb-org/6.0 multiverse"
     state: absent
     filename: "{{ mongo.list6 }}"
+
+- name: Remove APT Repository 7.0
+  ansible.builtin.apt_repository:
+    repo: "deb [arch={{ system_arch }} signed-by={{ mongo.keyring }}]
+      https://repo.mongodb.org/apt/{{ ansible_distribution | lower }} {{ ansible_distribution_release }}/mongodb-org/7.0 multiverse"
+    state: absent
+    filename: "{{ mongo.list7 }}"
 
 - name: Remove Mongo
   ansible.builtin.apt:

--- a/vars.yml
+++ b/vars.yml
@@ -53,12 +53,10 @@ docker:
 
 mongo:
   keyring: /usr/share/keyrings/mongodb-archive-keyring.gpg
+  path: https://www.mongodb.org/static/pgp/server-7.0.asc
+  list: /etc/apt/sources.list.d/mongodb-org
   path4: https://www.mongodb.org/static/pgp/server-4.4.asc
-  path6: https://www.mongodb.org/static/pgp/server-6.0.asc
-  path7: https://www.mongodb.org/static/pgp/server-7.0.asc
   list4: /etc/apt/sources.list.d/mongodb-org-4.4
-  list6: /etc/apt/sources.list.d/mongodb-org-6.0
-  list7: /etc/apt/sources.list.d/mongodb-org-7.0
   mongo4:
     packages:
       - name: mongodb-org

--- a/vars.yml
+++ b/vars.yml
@@ -55,8 +55,10 @@ mongo:
   keyring: /usr/share/keyrings/mongodb-archive-keyring.gpg
   path4: https://www.mongodb.org/static/pgp/server-4.4.asc
   path6: https://www.mongodb.org/static/pgp/server-6.0.asc
-  list6: /etc/apt/sources.list.d/mongodb-org-6.0
+  path7: https://www.mongodb.org/static/pgp/server-7.0.asc
   list4: /etc/apt/sources.list.d/mongodb-org-4.4
+  list6: /etc/apt/sources.list.d/mongodb-org-6.0
+  list7: /etc/apt/sources.list.d/mongodb-org-7.0
   mongo4:
     packages:
       - name: mongodb-org


### PR DESCRIPTION
- Install MongoDB version 7.0 when AVX is supported and OS is Focal or Jammy.

** This removes installation of version 6.0, but keeps the purge for 6.0 in place.