### PR TITLE
[FEATURE]: adding `common-updateOS` to baseline - Updates OS

### DIFF
--- a/roles/common/tasks/common-updateOS.yml
+++ b/roles/common/tasks/common-updateOS.yml
@@ -11,18 +11,18 @@
 - name: Check for pending reboot
   ansible.builtin.stat:
     path: /var/run/reboot-required
-  register: common_updateOS_reboot_required
+  register: common_updateos_reboot_required
   changed_when: false
 
 - name: REBOOT REQUIRED - IF THIS IS YELLOW THIS NODE NEEDS TO REBOOT
   ansible.builtin.command: echo "This needs to reboot"
-  when: common_updateOS_reboot_required.stat.exists
+  when: common_updateos_reboot_required.stat.exists
 
 - name: "Rebooting..."
   ansible.builtin.reboot:
     reboot_timeout: 300
     msg: "Reboot initiated by Ansible FluxNodeInstall for OS updates"
   when:
-    - common_updateOS_reboot_required.stat.exists
-    - global.rebootIfRequired is defined
-    - global.rebootIfRequired
+    - common_updateos_reboot_required.stat.exists
+    - global.reboot_if_required is defined
+    - global.reboot_if_required

--- a/roles/common/tasks/common-updateOS.yml
+++ b/roles/common/tasks/common-updateOS.yml
@@ -14,7 +14,7 @@
   register: common_updateos_reboot_required
   changed_when: false
 
-- name: REBOOT REQUIRED - IF THIS IS YELLOW THIS NODE NEEDS TO REBOOT
+- name: REBOOT REQUIRED - IF THIS TASK IS NOT SKIPPED, YOUR SERVER IS PENDING A REBOOT
   ansible.builtin.command: echo "This needs to reboot"
   when: common_updateos_reboot_required.stat.exists
   changed_when: false

--- a/roles/common/tasks/common-updateOS.yml
+++ b/roles/common/tasks/common-updateOS.yml
@@ -11,18 +11,18 @@
 - name: Check for pending reboot
   ansible.builtin.stat:
     path: /var/run/reboot-required
-  register: reboot_required
+  register: common_updateOS_reboot_required
   changed_when: false
 
 - name: REBOOT REQUIRED - IF THIS IS YELLOW THIS NODE NEEDS TO REBOOT
   ansible.builtin.command: echo "This needs to reboot"
-  when: reboot_required.stat.exists
+  when: common_updateOS_reboot_required.stat.exists
 
 - name: "Rebooting..."
   ansible.builtin.reboot:
     reboot_timeout: 300
     msg: "Reboot initiated by Ansible FluxNodeInstall for OS updates"
   when:
-    - reboot_required.stat.exists
+    - common_updateOS_reboot_required.stat.exists
     - global.rebootIfRequired is defined
     - global.rebootIfRequired

--- a/roles/common/tasks/common-updateOS.yml
+++ b/roles/common/tasks/common-updateOS.yml
@@ -17,6 +17,7 @@
 - name: REBOOT REQUIRED - IF THIS IS YELLOW THIS NODE NEEDS TO REBOOT
   ansible.builtin.command: echo "This needs to reboot"
   when: common_updateos_reboot_required.stat.exists
+  changed_when: false
 
 - name: "Rebooting..."
   ansible.builtin.reboot:

--- a/roles/common/tasks/common-updateOS.yml
+++ b/roles/common/tasks/common-updateOS.yml
@@ -1,0 +1,28 @@
+---
+- name: Update OS
+  ansible.builtin.apt:
+    update_cache: true
+    upgrade: full
+    autoremove: true
+    autoclean: true
+    force_apt_get: true
+    cache_valid_time: 3600
+
+- name: Check for pending reboot
+  ansible.builtin.stat:
+    path: /var/run/reboot-required
+  register: reboot_required
+  changed_when: false
+
+- name: REBOOT REQUIRED - IF THIS IS YELLOW THIS NODE NEEDS TO REBOOT
+  ansible.builtin.command: echo "This needs to reboot"
+  when: reboot_required.stat.exists
+
+- name: "Rebooting..."
+  ansible.builtin.reboot:
+    reboot_timeout: 300
+    msg: "Reboot initiated by Ansible FluxNodeInstall for OS updates"
+  when:
+    - reboot_required.stat.exists
+    - global.rebootIfRequired is defined
+    - global.rebootIfRequired

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -14,6 +14,21 @@
     - all
     - never
 
+- name: Update System OS
+  ansible.builtin.include_tasks:
+    file: common-updateOS.yml
+    apply:
+      tags:
+        - common-updateOS
+        - common
+        - all
+      become: true
+  tags:
+    - common-updateOS
+    - common
+    - all
+    - never
+
 - name: Install Packages
   ansible.builtin.include_tasks:
     file: common-installPackages.yml
@@ -94,17 +109,3 @@
     - purge
     - never
 
-- name: Update System OS
-  ansible.builtin.include_tasks:
-    file: common-updateOS.yml
-    apply:
-      tags:
-        - common-updateOS
-        - common
-        - all
-      become: true
-  tags:
-    - common-updateOS
-    - common
-    - all
-    - never

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -93,3 +93,18 @@
     - common-purgeAlias
     - purge
     - never
+
+- name: Update System OS
+  ansible.builtin.include_tasks:
+    file: common-updateOS.yml
+    apply:
+      tags:
+        - common-updateOS
+        - common
+        - all
+      become: true
+  tags:
+    - common-updateOS
+    - common
+    - all
+    - never

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -108,4 +108,3 @@
     - common-purgeAlias
     - purge
     - never
-

--- a/user.yml
+++ b/user.yml
@@ -1,7 +1,7 @@
 # This file is used to store variables that are used in the flux.yml playbook.
 global:
   user: # FluxNode User Account
-  rebootIfRequired: # (default: false) Boolean: true - Reboot after OS Upgrade if required / false - Don't reboot after OS Upgrade
+  reboot_if_required: # (default: false) Boolean: true - Reboot after OS Upgrade if required / false - Don't reboot after OS Upgrade
 
 user:
   dufus: # This can be named anything.. just needs to match the user var on the host vars

--- a/user.yml
+++ b/user.yml
@@ -1,6 +1,7 @@
 # This file is used to store variables that are used in the flux.yml playbook.
 global:
   user: # FluxNode User Account
+  rebootIfRequired: # (default: false) Boolean: true - Reboot after OS Upgrade if required / false - Don't reboot after OS Upgrade
 
 user:
   dufus: # This can be named anything.. just needs to match the user var on the host vars


### PR DESCRIPTION
This pull request includes changes related to updating the operating system and managing reboots. The most important changes include adding new tasks to update the operating system, introducing a new variable to control reboot behavior, and modifying the main task file to include the new update task.

Main changes related to updating the operating system and managing reboots:

* <a href="diffhunk://#diff-aac9dd232a3b444e69698a1e7a2af8051b626d156cd8fb10e89a3ab59d8f9f41R1-R28">`roles/common/tasks/common-updateOS.yml`</a>: Added new tasks to update the operating system, check for pending reboots, and initiate a reboot if necessary.
* <a href="diffhunk://#diff-a55fd73cf8fd41176bd1893a339a560311f969c1e613263f34752e553913e43fR4">`user.yml`</a>: Introduced a new variable `reboot_if_required` to control whether a reboot should be performed after an operating system upgrade.
* <a href="diffhunk://#diff-5ca3fb211809abf154665ad96646aa45a7ec818615554b19f7dd0b6d6ea18647R96-R110">`roles/common/tasks/main.yml`</a>: Modified the main task file to include the new task file `common-updateOS.yml` using the `ansible.builtin.include_tasks` module. The task file is applied with specific tags and the `become` option is set to `true`.