### PR TITLE
NVM repo updated to `nvm-sh`

### DIFF
--- a/vars.yml
+++ b/vars.yml
@@ -27,7 +27,7 @@ fluxbench:
   conf_file: "/home/{{ global.user }}/.fluxbenchmark/fluxbench.conf"
 
 nvm:
-  repo: https://raw.githubusercontent.com/creationix/nvm/master/install.sh
+  repo: https://raw.githubusercontent.com/nvm-sh/nvm/master/install.sh
   node:
     version: 16.19.1
 


### PR DESCRIPTION
This pull request updates the `nvm` repository URL in `vars.yml` to ensure that the latest version of `nvm` is used.

* <a href="diffhunk://#diff-f149cfca468975e4755d447af3239298fc0ce15a4c3015c469823073c211f9f2L30-R30">`vars.yml`</a>: Updated the `nvm` repository URL to ensure the latest version is used.