### PR TITLE
Creating a more robust nvm-purge.

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -1,7 +1,5 @@
 name: Ansible Lint
-on:
-  push:
-    branches: ['*']
+on: push
 
 jobs:
   lint:

--- a/roles/daemon/tasks/daemon-start.yml
+++ b/roles/daemon/tasks/daemon-start.yml
@@ -1,0 +1,8 @@
+---
+- name: Ensure Scripts Exist
+  ansible.builtin.include_tasks: daemon-scripts.yml
+
+- name: Start Daemon Service
+  ansible.builtin.command: "/home/{{ global.user }}/start_daemon_service.sh"
+  become: true
+  become_user: "{{ global.user }}"

--- a/roles/daemon/tasks/daemon-start.yml
+++ b/roles/daemon/tasks/daemon-start.yml
@@ -6,3 +6,4 @@
   ansible.builtin.command: "/home/{{ global.user }}/start_daemon_service.sh"
   become: true
   become_user: "{{ global.user }}"
+  changed_when: false

--- a/roles/daemon/tasks/daemon-stop.yml
+++ b/roles/daemon/tasks/daemon-stop.yml
@@ -7,3 +7,4 @@
   failed_when: false
   become: true
   become_user: "{{ global.user }}"
+  changed_when: false

--- a/roles/daemon/tasks/daemon-stop.yml
+++ b/roles/daemon/tasks/daemon-stop.yml
@@ -1,0 +1,9 @@
+---
+- name: Ensure Scripts Exist
+  ansible.builtin.include_tasks: daemon-scripts.yml
+
+- name: Stop Daemon Service
+  ansible.builtin.command: "/home/{{ global.user }}/stop_daemon_service.sh"
+  failed_when: false
+  become: true
+  become_user: "{{ global.user }}"

--- a/roles/daemon/tasks/main.yml
+++ b/roles/daemon/tasks/main.yml
@@ -71,3 +71,23 @@
     - daemon
     - all
     - never
+
+- name: Start Daemon Service
+  ansible.builtin.include_tasks:
+    file: daemon-start.yml
+    apply:
+      tags:
+        - daemon-start
+  tags:
+    - daemon-start
+    - never
+
+- name: Stop Daemon Service
+  ansible.builtin.include_tasks:
+    file: daemon-stop.yml
+    apply:
+      tags:
+        - daemon-stop
+  tags:
+    - daemon-stop
+    - never

--- a/roles/nvm/tasks/nvm-install.yml
+++ b/roles/nvm/tasks/nvm-install.yml
@@ -33,7 +33,7 @@
   become: true
   become_user: "{{ global.user }}"
 
-- name: Install Node {{ nvm.node.version }} with nvm and check version
+- name: Install Node with nvm and check version {{ nvm.node.version }}
   ansible.builtin.shell: |
     source /home/{{ global.user }}/.nvm/nvm.sh
     nvm install "{{ nvm.node.version }}"

--- a/roles/nvm/tasks/nvm-install.yml
+++ b/roles/nvm/tasks/nvm-install.yml
@@ -33,7 +33,7 @@
   become: true
   become_user: "{{ global.user }}"
 
-- name: Install Node 16 with nvm and check version
+- name: Install Node {{ nvm.node.version }} with nvm and check version
   ansible.builtin.shell: |
     source /home/{{ global.user }}/.nvm/nvm.sh
     nvm install "{{ nvm.node.version }}"

--- a/roles/nvm/tasks/nvm-purge.yml
+++ b/roles/nvm/tasks/nvm-purge.yml
@@ -1,4 +1,14 @@
 ---
+- name: Stopping Flux via PM2
+  ansible.builtin.include_role:
+    name: pm2
+    tasks_from: pm2-stop.yml
+
+- name: Stopping Daemon
+  ansible.builtin.include_role:
+    name: daemon
+    tasks_from: daemon-stop.yml
+
 - name: Remove nvm and node files
   ansible.builtin.file:
     path: "{{ item }}"


### PR DESCRIPTION
This is to prep for future functionality to upgrade `nvm`/`node` versions in the future, or upgrade when running `FluxNodeInstall` against a previously non-ansible managed FluxNode (node started with `multitoolbox` only).

This pull request introduces changes to the roles and tasks related to the daemon and nvm. The most important changes include the addition of new tasks for starting and stopping the daemon service, modifications to the nvm installation task to install a specific version of Node, and the addition of tasks to stop Flux via PM2 and stop the Daemon.

Summary of changes:

* <a href="diffhunk://#diff-fcc91f0955c3a87bf6c3e03640684e4e723283153c7dbbc4dfad659d72fcc4baR74-R93">`roles/daemon/tasks/main.yml`</a>: Added two new tasks, "Start Daemon Service" and "Stop Daemon Service", which include tasks from separate files.
* <a href="diffhunk://#diff-e7d33d165ef36679b20fa9e31a86a6b619669ce9d4fccf9a7430245e4e396159R1-R8">`roles/daemon/tasks/daemon-start.yml`</a>: Added a new task named "Ensure Scripts Exist" which includes tasks from the `daemon-scripts.yml` file.
* <a href="diffhunk://#diff-ffb1e8263ea589501b253186895d0924ca190f6ffd9b0684d765ea60c2aed2b1R1-R9">`roles/daemon/tasks/daemon-stop.yml`</a>: Added a new task named "Ensure Scripts Exist" which includes tasks from the `daemon-scripts.yml` file.
* <a href="diffhunk://#diff-c4f5a5bb8c501f04872e493e2f2366c5ad175921b5c0d4ab633bb9049e254679L36-R36">`roles/nvm/tasks/nvm-install.yml`</a>: Modified the task to install a specific version of Node using nvm.
* <a href="diffhunk://#diff-8dfad57c9c5569359b073d71d8a8f0503cca20a8f657ac7137db2fc7e504a2a4R2-R11">`roles/nvm/tasks/nvm-purge.yml`</a>: Added two new tasks to stop Flux via PM2 and stop the Daemon.