### PR TITLE
Updating mongo readme vars to match new structure made in #66

### DIFF
--- a/roles/mongo/README.md
+++ b/roles/mongo/README.md
@@ -23,12 +23,10 @@ global:
 
 mongo:
   keyring: # Keyring file path for APT
-  path4: # Path to MongoDB 4.4 APT key
-  list4: # Path to MongoDB 4.4 APT source list
-  path6: # Path to MongoDB 6.0 APT key
-  list6: # Path to MongoDB 6.0 APT source list
-  path7: # Path to MongoDB 7.0 APT key
-  list7: # Path to MongoDB 7.0 APT source list
+  path:    # Path to latest MongoDB APT key
+  list:    # Path to latest MongoDB APT source list
+  path4:   # Path to MongoDB 4.4 APT key
+  list4:   # Path to MongoDB 4.4 APT source list
   mongo4:
   # packages takes a list of dictionaries with the following keys:
     packages:


### PR DESCRIPTION
This pull request includes an update to the global section of the `roles/mongo/README.md` file to provide information about MongoDB installation and configuration. This was missed when #66 was merged.

Main documentation update:

* `roles/mongo/README.md`: Updated the global section of the README file to include information about MongoDB installation and configuration. (See lines 10-20)