### PR TITLE
Nvm/update node version

### DIFF
--- a/roles/nvm/tasks/nvm-install.yml
+++ b/roles/nvm/tasks/nvm-install.yml
@@ -1,5 +1,48 @@
 ---
-# Should we detect for an existing nvm / node is installed
+- name: Check if NVM is installed
+  ansible.builtin.command: command -v nvm
+  changed_when: false
+  failed_when: false
+  register: nvm_installed
+
+- name: Check if Node is installed
+  ansible.builtin.command: command -v node
+  args:
+    executable: /bin/bash -i
+  changed_when: false
+  failed_when: false
+  register: node_installed
+
+- name: Get Installed Node Version
+  ansible.builtin.command: node --version | cut -c2-
+  args:
+    executable: /bin/bash -i
+  register: node_version
+  changed_when: false
+  failed_when: false
+  when: node_installed.stdout != ""
+
+- name: Check if Node Update is needed
+  ansible.builtin.assert:
+    that:
+      - node_version.stdout | version(nvm.node.version, '!=')
+  register: node_update_needed
+  when: node_installed.stdout != ""
+
+# To trick ansible into running the purge tasks here,
+# we need to apply the 'install' tags to the purge tasks
+- name: Purge NVM and Node
+  ansible.builtin.include_role:
+    name: nvm
+    tasks_from: nvm-purge.yml
+    apply:
+      tags:
+        - nvm-install
+        - nvm
+        - all
+  when:
+    - node_update_needed is defined
+    - node_update_needed
 
 - name: Ensure NVM Directory exists
   ansible.builtin.file:

--- a/roles/nvm/tasks/nvm-install.yml
+++ b/roles/nvm/tasks/nvm-install.yml
@@ -1,31 +1,34 @@
 ---
 - name: Check if NVM is installed
-  ansible.builtin.command: command -v nvm
+  ansible.builtin.shell: command -v nvm
   changed_when: false
   failed_when: false
   register: nvm_installed
 
 - name: Check if Node is installed
-  ansible.builtin.command: command -v node
-  args:
-    executable: /bin/bash -i
+  ansible.builtin.shell: command -v node
   changed_when: false
   failed_when: false
   register: node_installed
 
 - name: Get Installed Node Version
-  ansible.builtin.command: node --version | cut -c2-
-  args:
-    executable: /bin/bash -i
+  ansible.builtin.shell: node --version | cut -c2-
   register: node_version
   changed_when: false
   failed_when: false
   when: node_installed.stdout != ""
 
+- name: Set Node Version
+  ansible.builtin.set_fact:
+    node_installed_version: "{{ node_version.stdout }}"
+  when: node_installed.stdout != ""
+
 - name: Check if Node Update is needed
   ansible.builtin.assert:
     that:
-      - node_version.stdout | version(nvm.node.version, '!=')
+      - node_installed_version is version_compare(nvm.node.version, '!=')
+    success_msg: "Node Version Needs to be Updated / Reinstalled."
+    fail_msg: "Node Version is already up to date."
   register: node_update_needed
   when: node_installed.stdout != ""
 
@@ -87,3 +90,51 @@
     creates: "/home/{{ global.user }}/.nvm/versions/node/v{{ nvm.node.version }}"
   become: true
   become_user: "{{ global.user }}"
+
+- name: Install Logrotate
+  ansible.builtin.include_role:
+    name: logrotate
+    tasks_from: logrotate-install.yml
+    apply:
+      tags:
+        - nvm-install
+        - nvm
+  when:
+    - node_update_needed is defined
+    - node_update_needed
+
+- name: Install PM2
+  ansible.builtin.include_role:
+    name: pm2
+    tasks_from: pm2-install.yml
+    apply:
+      tags:
+        - nvm-install
+        - nvm
+  when:
+    - node_update_needed is defined
+    - node_update_needed
+
+- name: Install Watchdog
+  ansible.builtin.include_role:
+    name: watchdog
+    tasks_from: watchdog-install.yml
+    apply:
+      tags:
+        - nvm-install
+        - nvm
+  when:
+    - node_update_needed is defined
+    - node_update_needed
+
+- name: Start PM2
+  ansible.builtin.include_role:
+    name: pm2
+    tasks_from: pm2-conf.yml
+    apply:
+      tags:
+        - nvm-install
+        - nvm
+  when:
+    - node_update_needed is defined
+    - node_update_needed

--- a/roles/nvm/tasks/nvm-purge.yml
+++ b/roles/nvm/tasks/nvm-purge.yml
@@ -9,6 +9,36 @@
     name: daemon
     tasks_from: daemon-stop.yml
 
+- name: Purge Logrotate
+  ansible.builtin.include_role:
+    name: logrotate
+    tasks_from: logrotate-purge.yml
+    apply:
+      tags:
+        - nvm-purge
+        - purge
+      become: true
+
+- name: Purge PM2
+  ansible.builtin.include_role:
+    name: pm2
+    tasks_from: pm2-purge.yml
+    apply:
+      tags:
+        - nvm-purge
+        - purge
+      become: true
+
+- name: Purge Watchdog
+  ansible.builtin.include_role:
+    name: watchdog
+    tasks_from: watchdog-purge.yml
+    apply:
+      tags:
+        - nvm-purge
+        - purge
+      become: true
+
 - name: Remove nvm and node files
   ansible.builtin.file:
     path: "{{ item }}"

--- a/roles/pm2/tasks/pm2-stop.yml
+++ b/roles/pm2/tasks/pm2-stop.yml
@@ -6,6 +6,7 @@
     source /home/{{ global.user }}/.nvm/nvm.sh
     {{ item }}
   changed_when: false
+  ignore_errors: true
   args:
     executable: /bin/bash
   loop:

--- a/vars.yml
+++ b/vars.yml
@@ -29,7 +29,7 @@ fluxbench:
 nvm:
   repo: https://raw.githubusercontent.com/nvm-sh/nvm/master/install.sh
   node:
-    version: 16.19.1
+    version: 20.9.0
 
 ip:
   url1: https://api.ipify.org


### PR DESCRIPTION
TLDR: Create an update / upgrade path for nvm/node versions without borking nodes. This will allow upgrades / downgrades to the `nvm.node.version` provided in the `vars.yml` file.

This pull request includes changes to the roles and variables related to NVM, Node, Logrotate, PM2, and Watchdog. The most important changes include adding tasks to check and install NVM and Node, installing Logrotate, PM2, and Watchdog, and updating the Node version in the `vars.yml` file.

Summary of changes:

* <a href="diffhunk://#diff-c4f5a5bb8c501f04872e493e2f2366c5ad175921b5c0d4ab633bb9049e254679L2-R48">`roles/nvm/tasks/nvm-install.yml`</a>: Added tasks to check if NVM and Node are installed, get the installed Node version, determine if a Node update is needed, install Logrotate, PM2, and Watchdog, and start PM2 after installation. <a href="diffhunk://#diff-c4f5a5bb8c501f04872e493e2f2366c5ad175921b5c0d4ab633bb9049e254679L2-R48">[1]</a> <a href="diffhunk://#diff-c4f5a5bb8c501f04872e493e2f2366c5ad175921b5c0d4ab633bb9049e254679R93-R140">[2]</a>
* <a href="diffhunk://#diff-8dfad57c9c5569359b073d71d8a8f0503cca20a8f657ac7137db2fc7e504a2a4R12-R41">`roles/nvm/tasks/nvm-purge.yml`</a>: Added tasks to purge Logrotate, PM2, and Watchdog with specific tags and elevated privileges.
* <a href="diffhunk://#diff-5580739af52e3b23a2c760d9568fde1cf6b6b794f40b7f2635f0f5f18aec8d78R9">`roles/pm2/tasks/pm2-stop.yml`</a>: Added the `ignore_errors` option to the `ansible.builtin.shell` task to allow it to continue executing even if it encounters an error.
* <a href="diffhunk://#diff-f149cfca468975e4755d447af3239298fc0ce15a4c3015c469823073c211f9f2L32-R32">`vars.yml`</a>: Updated the Node version from `16.19.1` to `20.9.0` to specify the desired version of Node to be installed.