### PR TITLE
updating mongo key url

### DIFF
--- a/vars.yml
+++ b/vars.yml
@@ -53,7 +53,7 @@ docker:
 
 mongo:
   keyring: /usr/share/keyrings/mongodb-archive-keyring.gpg
-  path: https://www.mongodb.org/static/pgp/server-7.0.asc
+  path: https://pgp.mongodb.com/server-7.0.asc
   list: /etc/apt/sources.list.d/mongodb-org
   path4: https://www.mongodb.org/static/pgp/server-4.4.asc
   list4: /etc/apt/sources.list.d/mongodb-org-4.4


### PR DESCRIPTION
This pull request updates the `path` for the `mongo` configuration in `vars.yml` to `https://pgp.mongodb.com/server-7.0.asc`, which updates the path to the MongoDB server keyring.

* <a href="diffhunk://#diff-f149cfca468975e4755d447af3239298fc0ce15a4c3015c469823073c211f9f2L56-R56">`vars.yml`</a>: Updated the `path` for the `mongo` configuration to `https://pgp.mongodb.com/server-7.0.asc`, which updates the path to the MongoDB server keyring.