### PR TITLE
Updating Mongo 4.4 key.

### DIFF
--- a/vars.yml
+++ b/vars.yml
@@ -55,7 +55,7 @@ mongo:
   keyring: /usr/share/keyrings/mongodb-archive-keyring.gpg
   path: https://pgp.mongodb.com/server-7.0.asc
   list: /etc/apt/sources.list.d/mongodb-org
-  path4: https://www.mongodb.org/static/pgp/server-4.4.asc
+  path4: https://pgp.mongodb.com/server-4.4.asc
   list4: /etc/apt/sources.list.d/mongodb-org-4.4
   mongo4:
     packages:


### PR DESCRIPTION
This pull request includes a single change to update the `path4` variable in the `mongo` section of `vars.yml` to point to the correct location for the MongoDB server 4.4.asc file.

* <a href="diffhunk://#diff-f149cfca468975e4755d447af3239298fc0ce15a4c3015c469823073c211f9f2L58-R58">`vars.yml`</a>: Updated the `path4` variable in the `mongo` section to point to the correct location for the MongoDB server 4.4.asc file.