### PR TITLE
fix(logrotate): Needs become permissions.

### DIFF
--- a/roles/logrotate/tasks/logrotate-clean.yml
+++ b/roles/logrotate/tasks/logrotate-clean.yml
@@ -4,4 +4,5 @@
     path: "/etc/logrotate.d/{{ item.name }}"
     state: absent
     force: true
+  become: true
   loop: "{{ logrotate.legacy }}"


### PR DESCRIPTION
This pull request includes a small but significant change to the `roles/logrotate/tasks/logrotate-clean.yml` file. The change ensures that the task is performed with elevated privileges by adding the `become: true` line. This means that the task will now be executed as the root user, which is necessary for operations that require higher permissions.